### PR TITLE
use .atom-text-editor instead of .editor

### DIFF
--- a/index.less
+++ b/index.less
@@ -1,4 +1,4 @@
-.editor {
+.atom-text-editor {
   &, .gutter {
     background-color: #2b2b2b;
     color: #e6e1dc;


### PR DESCRIPTION
Target the selector `:host, atom-text-editor` instead of `.editor` for
shadow DOM support.