### PR TITLE
let search highlight more clear

### DIFF
--- a/styles/syntax-variables.less
+++ b/styles/syntax-variables.less
@@ -6,7 +6,7 @@
 // General colors
 @syntax-text-color:                       @off-white;
 @syntax-cursor-color:                     @white;
-@syntax-selection-color:                  @dark-blue;
+@syntax-selection-color:                  fadeout(@white, 90%);
 @syntax-selection-flash-color:            @white;
 @syntax-background-color:                 @dark-gray;
 


### PR DESCRIPTION
when searching, the selected highlight syntax is illegible. change the color and opacity referenced from Textmate theme
